### PR TITLE
Strain recovery coupling with beam analysis

### DIFF
--- a/src/section.jl
+++ b/src/section.jl
@@ -899,7 +899,7 @@ end
 
 
 """
-    strain_recovery(F, M, nodes, elements, cache; gxbeam_order=false)
+    strain_recovery(F, M, nodes, elements, cache; gxbeam_order=true)
 
 Compute stresses and strains at each element in cross section.
 
@@ -912,7 +912,7 @@ Compute stresses and strains at each element in cross section.
     (thus must initialize cache and pass it to both compliance and this function)
 
 # Keyword Arguments
-- `gxbeam_order=false::Bool`: if true, `F`` and `M` are assumed to be in the 
+- `gxbeam_order=true::Bool`: if true, `F`` and `M` are assumed to be in the 
     local beam axis used by GXBeam (where the beam extends along the x-axis). This
     also returns beam stresses and strains in the axis order set by GXBeam 
     (e.g. axial stresses would correspond to the `xx` direction, or first index).
@@ -925,7 +925,7 @@ Compute stresses and strains at each element in cross section.
 - `strain_p::Vector(6, ne)`: strains in ply coordinate system for each element. order: 11, 22, 33, 12, 13, 23
 - `stress_p::Vector(6, ne)`: stresses in ply coordinate system for each element. order: 11, 22, 33, 12, 13, 23
 """
-function strain_recovery(F, M, nodes, elements, cache; gxbeam_order=false)
+function strain_recovery(F, M, nodes, elements, cache; gxbeam_order=true)
 
     # initialize outputs
     T = promote_type(eltype(F), eltype(M))
@@ -940,7 +940,7 @@ function strain_recovery(F, M, nodes, elements, cache; gxbeam_order=false)
         new_idxs = [2,3,1]
         theta = vcat(SVector{3}(F[new_idxs]), SVector{3}(M[new_idxs])) # convert input loads from GXBeam local frame to stress recovery local frame
     else
-    theta = vcat(SVector{3}(F), SVector{3}(M))
+        theta = vcat(SVector{3}(F), SVector{3}(M))
     end
 
     # indices into global matrices

--- a/src/section.jl
+++ b/src/section.jl
@@ -899,7 +899,7 @@ end
 
 
 """
-    strain_recovery(F, M, nodes, elements, cache)
+    strain_recovery(F, M, nodes, elements, cache; gxbeam_order=false)
 
 Compute stresses and strains at each element in cross section.
 
@@ -911,13 +911,21 @@ Compute stresses and strains at each element in cross section.
 - `cache::SectionCache`: needs to reuse data from the compliance solve
     (thus must initialize cache and pass it to both compliance and this function)
 
+# Keyword Arguments
+- `gxbeam_order=false::Bool`: if true, `F`` and `M` are assumed to be in the 
+    local beam axis used by GXBeam (where the beam extends along the x-axis). This
+    also returns beam stresses and strains in the axis order set by GXBeam 
+    (e.g. axial stresses would correspond to the `xx` direction, or first index).
+
 # Returns
 - `strain_b::Vector(6, ne)`: strains in beam coordinate system for each element. order: xx, yy, zz, xy, xz, yz
+    Note: this order (as well as those below) corresponds to the local beam reference frame if `gxbeam_order` 
+    is set to `true`.
 - `stress_b::Vector(6, ne)`: stresses in beam coordinate system for each element. order: xx, yy, zz, xy, xz, yz
 - `strain_p::Vector(6, ne)`: strains in ply coordinate system for each element. order: 11, 22, 33, 12, 13, 23
 - `stress_p::Vector(6, ne)`: stresses in ply coordinate system for each element. order: 11, 22, 33, 12, 13, 23
 """
-function strain_recovery(F, M, nodes, elements, cache)
+function strain_recovery(F, M, nodes, elements, cache; gxbeam_order=false)
 
     # initialize outputs
     T = promote_type(eltype(F), eltype(M))
@@ -928,13 +936,22 @@ function strain_recovery(F, M, nodes, elements, cache)
     sigma_p = Matrix{T}(undef, 6, ne)
 
     # concatenate forces/moments
+    if gxbeam_order
+        new_idxs = [2,3,1]
+        theta = vcat(SVector{3}(F[new_idxs]), SVector{3}(M[new_idxs])) # convert input loads from GXBeam local frame to stress recovery local frame
+    else
     theta = vcat(SVector{3}(F), SVector{3}(M))
+    end
 
     # indices into global matrices
     idx = cache.idx
 
     # save reordering index
-    idx_b = [1, 2, 6, 3, 4, 5]   # xx, yy, zz, xy, xz, yz
+    if gxbeam_order
+        idx_b = [6, 1, 2, 5, 3, 4]   # zz, xx, yy, yz, xy, xz
+    else
+        idx_b = [1, 2, 6, 3, 4, 5]   # xx, yy, zz, xy, xz, yz
+    end
     idx_p = [6, 1, 2, 4, 5, 3]   # 11, 22, 33, 12, 13, 23
 
     # iterate over elements

--- a/test/section.jl
+++ b/test/section.jl
@@ -565,7 +565,7 @@ linearinterp(xdata, ydata, x::AbstractVector) = linearinterp.(Ref(xdata), Ref(yd
 
     F = [0.0; 0; 0]
     M = [-1000.0; 0; 0]
-    epsilon_b, sigma_b, epsilon_p, sigma_p = strain_recovery(F, M, nodes, elements, cache)
+    epsilon_b, sigma_b, epsilon_p, sigma_p = strain_recovery(F, M, nodes, elements, cache; gxbeam_order=false)
 
     # using PyPlot
     # pygui(true); close("all")
@@ -884,7 +884,7 @@ end
 
     F = [0.0; 0; 0]
     M = [0.0; 0; 1e6]
-    epsilon_b, sigma_b, epsilon_p, sigma_p = strain_recovery(F, M, nodes, elements, cache)
+    epsilon_b, sigma_b, epsilon_p, sigma_p = strain_recovery(F, M, nodes, elements, cache; gxbeam_order=false)
 
     idx = 585:-1:571
     n = length(idx)


### PR DESCRIPTION
The coordinate system that the `strain_recovery` method assumes the input loading is in is not the same as the local beam coordinate system. This update adds a keyword argument `gxbeam_order` (similar to the `compliance_matrix` method) that , if true, updates the input loading to the correct coordiante system and then outputs beam stresses and strains in the GXBeam local frame. If it is `false` nothing is changed from before. I added an additional test for this. 

In the future it would be good to add an example of this to the docs, as currently none of the examples couple the output of the beam analysis with strain recovery; the loads are explicitly defined.