### PR TITLE
Fix sensitivity analysis for step_system!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GXBeam"
 uuid = "974624c9-1acb-4ad6-a627-8ac40fc27a3e"
 authors = ["Taylor McDonnell <taylor.golden.mcdonnell@gmail.com> and Andrew Ning"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"

--- a/src/analyses.jl
+++ b/src/analyses.jl
@@ -3081,6 +3081,14 @@ function step_system!(system::DynamicSystem, paug, x, constants, initial_state, 
     # update paug with sensitivity parameters, if they exist
     if !isnothing(p)
         np = length(assembly.points)
+        required_len = 12 * np + length(p)
+        if length(paug) < required_len
+            throw(ArgumentError(
+                "paug has length $(length(paug)), but at least $required_len elements " *
+                "are required to store initialization terms for $(np) points and a " *
+                "parameter vector p of length $(length(p)).",
+            ))
+        end
         paug[12*np + 1 : 12*np + length(p)] .= p
     end
 

--- a/src/analyses.jl
+++ b/src/analyses.jl
@@ -3078,6 +3078,15 @@ function step_system!(system::DynamicSystem, paug, x, constants, initial_state, 
         paug[irate+10:irate+12] = 2/dt*Ω + Ωdot
     end
 
+    # update paug with sensitivity parameters, if they exist
+    if !isnothing(p)
+        np = length(assembly.points)
+        paug[12*np + 1 : 12*np + length(p)] .= p
+    end
+
+
+
+
     # solve for the new set of state variables
     if linear
         if update_linearization
@@ -3207,8 +3216,6 @@ function take_step(x, dx, system, assembly, t, tprev,
     #TODO: Make an inplace version that doesn't allocate.
     @unpack force_scaling, indices = system
 
-    # @show x
-    # @show dx
 
     ### Prepare the vector of design vars (which includes the states and state rates)
     if isnothing(p)
@@ -3485,8 +3492,6 @@ function newmark_output(system, x, p, constants)
     dual_safe_copy!(system.x, x)
     dual_safe_copy!(system.dx, dx)
 
-    # @show x
-    # @show dx
 
     # return result
     return AssemblyState(dx, x, system, assembly; prescribed_conditions=pcond)

--- a/src/analyses.jl
+++ b/src/analyses.jl
@@ -3092,9 +3092,6 @@ function step_system!(system::DynamicSystem, paug, x, constants, initial_state, 
         paug[12*np + 1 : 12*np + length(p)] .= p
     end
 
-
-
-
     # solve for the new set of state variables
     if linear
         if update_linearization


### PR DESCRIPTION
## Summary
- Adds sensitivity parameters to `paug` in `step_system!` when design variables `p` are provided, fixing incorrect sensitivity analysis for the implicit Euler stepper
- Removes leftover debug `@show` statements from `take_step` and `newmark_output`

## Test plan
- [ ] Existing `step_system!` / `implicit_euler` tests pass (CI)
- [ ] Verify sensitivity values are correct when using `ImplicitAD` with `step_system!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)